### PR TITLE
🔧 chore: Update httpx dependency version and enhance scheduled job configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 requires-python = ">=3.10,<3.13"
 keywords = ["nonebot", "nonebot2", "fortnite"]
 dependencies = [
-    "httpx>=0.27.0,<1.0.0",
+    "httpx>=0.27.2,<1.0.0",
     "aiofiles>=24.0.0",
     "aiohttp>=3.11.18,<4.0.0",
     "pillow>=11.2.1",

--- a/src/nonebot_plugin_fortnite/__init__.py
+++ b/src/nonebot_plugin_fortnite/__init__.py
@@ -31,6 +31,7 @@ from .stats import get_level, get_stats_image
     id="fortnite",
     hour=8,
     minute=5,
+    misfire_grace_time=300,
 )
 async def _():
     logger.info("开始更新商城/VB图...")

--- a/uv.lock
+++ b/uv.lock
@@ -722,7 +722,7 @@ requires-dist = [
     { name = "aiofiles", specifier = ">=24.0.0" },
     { name = "aiohttp", specifier = ">=3.11.18,<4.0.0" },
     { name = "fortnite-api", extras = ["speed"], specifier = ">=3.2.1,<4.0.0" },
-    { name = "httpx", specifier = ">=0.27.0,<1.0.0" },
+    { name = "httpx", specifier = ">=0.27.2,<1.0.0" },
     { name = "nonebot-plugin-alconna", specifier = ">=0.57.2,<1.0.0" },
     { name = "nonebot-plugin-apscheduler", specifier = ">=0.5.0,<1.0.0" },
     { name = "nonebot-plugin-localstore", specifier = ">=0.7.3,<1.0.0" },


### PR DESCRIPTION
- Bumped `httpx` version from `0.27.0` to `0.27.2` in `pyproject.toml` and `uv.lock` for improved performance and security.
- Added `misfire_grace_time` parameter to the scheduled job in the Fortnite plugin to allow for better handling of job execution timing.